### PR TITLE
Add universal `listen` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 byteorder = "1.2.7"
 serde = {version = "1.0.87", features = ["derive"]}
-
+service-binding = "0.1.1"
 bytes = { version = "0.4.11", optional = true }
 futures = { version = "0.1.25", optional = true }
 log = { version = "0.4.6", optional = true }


### PR DESCRIPTION
This function accepts anything that can be converted into
`service_binding::Listener` and that includes standard library's
`UnixListener` and `TcpListener`. This makes the `listen` method one
universal function that should be preferred.

Since `listen` does not expose any Tokio 0.x types and `service_binding`
has no dependencies this feature has minimal weight.