### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,21 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for lints
         run: cargo clippy -- -D warnings
+
+  integration:
+    name: Integration tests
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        include:
+        - os: windows-latest
+          windows: true
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run integration tests
+        run: ./tests/sign-and-verify.sh
+        if: ${{ ! matrix.windows }}
+      - name: Run integration tests
+        run: ".\\tests\\sign-and-verify-win.bat"
+        if: ${{ matrix.windows }}

--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -189,6 +189,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::main]
 #[cfg(windows)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // This is only used for integration tests on Windows:
+    std::fs::File::create("server-started")?;
+    // ^ You can remove this line
     KeyStorageAgent::new()
         .listen(NamedPipeListener::new(r"\\.\pipe\agent".into())?)
         .await?;

--- a/tests/sign-and-verify-win.bat
+++ b/tests/sign-and-verify-win.bat
@@ -1,0 +1,26 @@
+rem del /F /Q Cargo.toml.sig id_rsa id_rsa.pub agent.pub
+
+cmd /c "START /b cargo run --example key_storage"
+
+@echo off
+:waitloop
+IF EXIST "server-started" GOTO waitloopend
+rem timeout doesn't work in github actions so introduce delay some other way
+rem see https://stackoverflow.com/a/75054929
+ping localhost >nul
+goto waitloop
+:waitloopend
+@echo on
+
+ssh-keygen -t rsa -f id_rsa -N ""
+set SSH_AUTH_SOCK=\\.\pipe\agent
+ssh-add id_rsa
+ssh-add -L | tee agent.pub
+
+ssh-keygen -Y sign -f agent.pub -n file < Cargo.toml > Cargo.toml.sig
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+ssh-keygen -Y check-novalidate -n file -f agent.pub -s Cargo.toml.sig < Cargo.toml
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+rem del /F /Q Cargo.toml.sig id_rsa id_rsa.pub agent.pub

--- a/tests/sign-and-verify.sh
+++ b/tests/sign-and-verify.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+rm -rf ssh-agent.sock Cargo.toml.sig id_rsa id_rsa.pub agent.pub
+
+cargo run --example key_storage &
+
+while [ ! -e ssh-agent.sock ]; do
+  echo "Waiting for ssh-agent.sock"
+  sleep 1
+done
+
+ssh-keygen -t rsa -f id_rsa -N ""
+export SSH_AUTH_SOCK=ssh-agent.sock
+ssh-add id_rsa
+ssh-add -L | tee agent.pub
+ssh-keygen -Y sign -f agent.pub -n file < Cargo.toml > Cargo.toml.sig
+ssh-keygen -Y check-novalidate -n file -f agent.pub -s Cargo.toml.sig < Cargo.toml
+
+rm -rf ssh-agent.sock Cargo.toml.sig id_rsa id_rsa.pub agent.pub
+


### PR DESCRIPTION
This PR addresses the problem of checking if the agent is properly functioning for it's most basic task: signing requests.

Instead of spawning a new sshd daemon this PR takes a different approach: using SSH file signatures which execute the same piece of code.

On Windows a slight change is required: a file is created to signal to the script that it's ready to serve requests. Sadly it doesn't seem that checking `IF EXISTS "\\.\pipe\agent"` works :/