### PR TITLE
Document MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 ]
 repository = "https://github.com/wiktor-k/ssh-agent-lib"
 edition = "2021"
+rust-version = "1.75"
 keywords = ["ssh", "agent", "authentication", "openssh", "async"]
 categories = ["authentication", "cryptography", "encoding", "network-programming", "parsing"]
 exclude = [".github"]


### PR DESCRIPTION
Return-position `impl Trait` in traits requires Rust 1.75.

- https://github.com/wiktor-k/ssh-agent-lib/blob/3263c3d04900078c287880e76177ebd717c5540f/src/agent.rs#L145
- https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html