### PR TITLE
Add Encode traits for remaining message types (RustCrypto branch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-str"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +898,7 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "byteorder",
+ "const-str",
  "env_logger",
  "futures",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ testresult = "0.4.0"
 hex-literal = "0.4.1"
 ssh-key = { version = "0.6.4", features = ["p256"] }
 p256 = { version = "0.13.2" }
+const-str = "0.5.7"

--- a/src/proto/extension.rs
+++ b/src/proto/extension.rs
@@ -41,10 +41,8 @@ impl Decode for RestrictDestination {
     type Error = crate::proto::error::ProtoError;
 
     fn decode(reader: &mut impl Reader) -> Result<Self, Self::Error> {
-        eprintln!("encoding {}", u32::decode(reader)?);
         let mut constraints = Vec::new();
         while !reader.is_finished() {
-            eprintln!("encoding");
             constraints.push(reader.read_prefixed(DestinationConstraint::decode)?);
         }
         Ok(Self { constraints })
@@ -65,28 +63,25 @@ impl Decode for DestinationConstraint {
     type Error = crate::proto::error::ProtoError;
 
     fn decode(reader: &mut impl Reader) -> Result<Self, Self::Error> {
-        //eprintln!("before: {}", u32::decode(reader)?);
-        let from_username = String::decode(reader)?;
-        eprintln!("from username: {from_username} {}", from_username.len());
-        eprintln!("before: {}", u32::decode(reader)?);
-        let from_hostname = String::decode(reader)?;
-        eprintln!("from hostname: {from_hostname}");
-        let from_hostkeys = reader.read_prefixed(|reader| {
+        fn read_user_host_keys(
+            reader: &mut impl Reader,
+        ) -> Result<(String, String, Vec<KeySpec>), crate::proto::error::ProtoError> {
+            let username = String::decode(reader)?;
+            let hostname = String::decode(reader)?;
+            let _reserved = String::decode(reader)?;
+
             let mut keys = Vec::new();
             while !reader.is_finished() {
                 keys.push(KeySpec::decode(reader)?);
             }
-            Ok::<_, crate::proto::error::ProtoError>(keys)
-        })?;
-        let to_username = String::decode(reader)?;
-        let to_hostname = String::decode(reader)?;
-        let to_hostkeys = reader.read_prefixed(|reader| {
-            let mut keys = Vec::new();
-            while !reader.is_finished() {
-                keys.push(KeySpec::decode(reader)?);
-            }
-            Ok::<_, crate::proto::error::ProtoError>(keys)
-        })?;
+
+            Ok((username, hostname, keys))
+        }
+
+        let (from_username, from_hostname, from_hostkeys) =
+            reader.read_prefixed(read_user_host_keys)?;
+        let (to_username, to_hostname, to_hostkeys) = reader.read_prefixed(read_user_host_keys)?;
+        let _reserved = String::decode(reader)?;
         Ok(Self {
             from_username,
             from_hostname,
@@ -119,6 +114,7 @@ impl Decode for KeySpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hex_literal::hex;
     use testresult::TestResult;
 
     #[test]
@@ -141,28 +137,72 @@ mod tests {
 
     #[test]
     fn parse_destination_constraint() -> TestResult {
-        let mut buffer: &[u8] = &[
-            0, 0, 0, 114, //
-            0, 0, 0, 110, //
-            0, 0, 0, 12, //from:
-            0, 0, 0, 0, //username
-            0, 0, 0, 0, //hostname
-            0, 0, 0, 0, //reserved
+        let mut msg = &hex!(
+            "                                    00
+            0002 6f00 0000 0c00 0000 0000 0000 0000
+            0000 0000 0002 5700 0000 0000 0000 0a67
+            6974 6875 622e 636f 6d00 0000 0000 0000
+            3300 0000 0b73 7368 2d65 6432 3535 3139
+            0000 0020 e32a aa79 15ce b9b4 49d1 ba50
+            ea2a 28bb 1a6e 01f9 0bda 245a 2d1d 8769
+            7d18 a265 0000 0001 9700 0000 0773 7368
+            2d72 7361 0000 0003 0100 0100 0001 8100
+            a3ee 774d c50a 3081 c427 8ec8 5c2e ba8f
+            1228 a986 7b7e 5534 ef0c fea6 1c12 fd8f
+            568d 5246 3851 ed60 bf09 c62d 594e 8467
+            98ae 765a 3204 4aeb e3ca 0945 da0d b0bb
+            aad6 d6f2 0224 84be da18 2b0e aff0 b9e9
+            224c cbf0 4265 fc5d d675 b300 ec52 0cf8
+            15b2 67ab 3816 1f36 a96d 57df e158 2a81
+            cb02 0d21 1fb9 7488 3a25 327b da97 04a4
+            48dc 6205 e413 6604 1575 7524 79ec 2a06
+            cb58 d961 49ca 9bd9 49b2 4644 32ca d44b
+            b4bf b7f1 31b1 9310 9f96 63be e59f 0249
+            2358 ec68 9d8c c219 ed0e 3332 3036 9f59
+            c6ae 54c3 933c 030a cc3e c2a1 4f19 0035
+            efd7 277c 658e 5915 6bba 3d7a cfa5 f2bf
+            1be3 2706 f3d3 0419 ef95 cae6 d292 6fb1
+            4dc9 e204 b384 d3e2 393e 4b87 613d e014
+            0b9c be6c 3622 ad88 0ce0 60bb b849 f3b6
+            7672 6955 90ec 1dfc d402 b841 daf0 b79d
+            59a8 4c4a 6d0a 5350 d9fe 123a a84f 0bea
+            363e 24ab 1e50 5022 344e 14bf 6243 b124
+            25e6 3d45 996e 18e9 0a0e 7a8b ed9a 07a0
+            a62b 6246 867e 7b2b 99a3 d0c3 5d05 7038
+            fd69 f01f a5e8 3d62 732b 9372 bb6c c1de
+            7019 a7e4 b986 942c fa9d 6f37 5ff0 b239
+            0000 0000 6800 0000 1365 6364 7361 2d73
+            6861 322d 6e69 7374 7032 3536 0000 0008
+            6e69 7374 7032 3536 0000 0041 0449 8a48
+            4363 4047 b33a 6c64 64cc bba2 92a0 c050
+            7d9e 4b79 611a d832 336e 1b93 7cee e460
+            83a0 8bad ba39 c007 53ff 2eaf d262 95d1
+            4db0 d166 7660 1ffe f93a 6872 4800 0000
+            0000"
+        )[..];
+        let _destination_constraint = RestrictDestination::decode(&mut msg)?;
+
+        #[rustfmt::skip]
+        let mut buffer: &[u8] = const_str::concat_bytes!(
+            [0, 0, 0, 114], //
+            [0, 0, 0, 12], //from:
+            [0, 0, 0, 0], //username
+            [0, 0, 0, 0], //hostname
+            [0, 0, 0, 0], //reserved
             // no host keys here
-            0, 0, 0, 86, //to:
-            0, 0, 0, 6, 119, 105, 107, 116, 111, 114, // wiktor
-            0, 0, 0, 12, 109, 101, 116, 97, 99, 111, 100, 101, 46, 98, 105,
-            122, // metacode.biz
-            0, 0, 0, 0, // reserved, not in the spec authfd.c:469
-            0, 0, 0, 51, //
-            0, 0, 0, 11, //
-            115, 115, 104, 45, 101, 100, 50, 53, 53, 49, 57, //ssh-ed25519
-            0, 0, 0, 32, // raw key
-            177, 185, 198, 92, 165, 45, 127, 95, 202, 195, 226, 63, 6, 115, 10, 104, 18, 137, 172,
-            240, 153, 154, 174, 74, 83, 7, 1, 204, 14, 177, 153, 40, //
-            0,  // is_ca
-            0, 0, 0, 0, // reserved, not in the spec, authfd.c:495
-        ];
+            [0, 0, 0, 86], //to:
+            [0, 0, 0, 6], b"wiktor",
+            [0, 0, 0, 12], b"metacode.biz",
+            [0, 0, 0, 0], // reserved, not in the spec authfd.c:469
+            [0, 0, 0, 51], //
+            [0, 0, 0, 11], //
+            b"ssh-ed25519",
+            [0, 0, 0, 32], // raw key
+            [177, 185, 198, 92, 165, 45, 127, 95, 202, 195, 226, 63, 6, 115, 10, 104, 18, 137, 172,
+            240, 153, 154, 174, 74, 83, 7, 1, 204, 14, 177, 153, 40], //
+            [0],  // is_ca
+            [0, 0, 0, 0], // reserved, not in the spec, authfd.c:495
+        );
 
         let destination_constraint = RestrictDestination::decode(&mut buffer)?;
         eprintln!("Destination constraint: {destination_constraint:?}");

--- a/src/proto/message.rs
+++ b/src/proto/message.rs
@@ -311,6 +311,16 @@ impl From<Vec<u8>> for Unparsed {
     }
 }
 
+impl Encode for Unparsed {
+    fn encoded_len(&self) -> ssh_encoding::Result<usize> {
+        self.0.encoded_len()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
+        self.0.encode(writer)
+    }
+}
+
 pub type Passphrase = String;
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/proto/message.rs
+++ b/src/proto/message.rs
@@ -74,7 +74,7 @@ impl Decode for SignRequest {
 impl Encode for SignRequest {
     fn encoded_len(&self) -> ssh_encoding::Result<usize> {
         [
-            self.pubkey.encoded_len()?,
+            self.pubkey.encoded_len_prefixed()?,
             self.data.encoded_len()?,
             self.flags.encoded_len()?,
         ]
@@ -82,7 +82,7 @@ impl Encode for SignRequest {
     }
 
     fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
-        self.pubkey.encode(writer)?;
+        self.pubkey.encode_prefixed(writer)?;
         self.data.encode(writer)?;
         self.flags.encode(writer)?;
 
@@ -177,6 +177,16 @@ impl Decode for RemoveIdentity {
     }
 }
 
+impl Encode for RemoveIdentity {
+    fn encoded_len(&self) -> ssh_encoding::Result<usize> {
+        self.pubkey.encoded_len_prefixed()
+    }
+    
+    fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
+        self.pubkey.encode_prefixed(writer)
+    }
+}
+
 #[derive(Clone, PartialEq, Debug)]
 pub struct SmartcardKey {
     pub id: String,
@@ -191,6 +201,19 @@ impl Decode for SmartcardKey {
         let pin = String::decode(reader)?;
 
         Ok(Self { id, pin })
+    }
+}
+
+impl Encode for SmartcardKey {
+    fn encoded_len(&self) -> ssh_encoding::Result<usize> {
+        [self.id.encoded_len()?, self.pin.encoded_len()?].checked_sum()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
+        self.id.encode(writer)?;
+        self.pin.encode(writer)?;
+
+        Ok(())
     }
 }
 
@@ -231,7 +254,7 @@ impl Encode for KeyConstraint {
                 .ok_or(EncodingError::Length),
             Self::Confirm => Ok(base),
             Self::Extension(name, content) => {
-                [base, name.encoded_len()?, content.encoded_len()?].checked_sum()
+                [base, name.encoded_len()?, content.0.encoded_len()?].checked_sum()
             }
         }
     }
@@ -246,7 +269,7 @@ impl Encode for KeyConstraint {
             Self::Extension(name, content) => {
                 255u8.encode(writer)?;
                 name.encode(writer)?;
-                content.encode(writer)
+                content.0.encode(writer)
             }
         }
     }
@@ -272,6 +295,25 @@ impl Decode for AddSmartcardKeyConstrained {
     }
 }
 
+impl Encode for AddSmartcardKeyConstrained {
+    fn encoded_len(&self) -> ssh_encoding::Result<usize> {
+        self.constraints
+        .iter()
+        .try_fold(self.key.encoded_len()?, |acc, e| {
+            let constraint_len = e.encoded_len()?;
+            usize::checked_add(acc, constraint_len).ok_or(EncodingError::Length)
+        })
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
+        self.key.encode(writer)?;
+        for constraint in &self.constraints {
+            constraint.encode(writer)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, PartialEq, Debug)]
 pub struct Extension {
     pub name: String,
@@ -289,6 +331,23 @@ impl Decode for Extension {
             name,
             details: details.into(),
         })
+    }
+}
+
+impl Encode for Extension {
+    fn encoded_len(&self) -> ssh_encoding::Result<usize> {
+        [
+            self.name.encoded_len()?,
+            self.details.0.encoded_len()?
+        ].checked_sum()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
+        self.name.encode(writer)?;
+
+        // NOTE: extension messages do not contain a length!
+        writer.write(&self.details.0[..])?;
+        Ok(())
     }
 }
 
@@ -341,7 +400,31 @@ pub enum Message {
     AddIdConstrained(AddIdentityConstrained),
     AddSmartcardKeyConstrained(AddSmartcardKeyConstrained),
     Extension(Extension),
-    ExtensionFailure,
+    ExtensionFailure
+}
+
+impl Message {
+    pub fn message_id(&self) -> u8 {
+        match self {
+            Message::Failure => 5,
+            Message::Success => 6,
+            Message::RequestIdentities => 11,
+            Message::IdentitiesAnswer(_) => 12,
+            Message::SignRequest(_) => 13,
+            Message::SignResponse(_) => 14,
+            Message::AddIdentity(_) => 17,
+            Message::RemoveIdentity(_) => 18,
+            Message::RemoveAllIdentities => 19,
+            Message::AddSmartcardKey(_) => 20,
+            Message::RemoveSmartcardKey(_) => 21,
+            Message::Lock(_) => 22,
+            Message::Unlock(_) => 23,
+            Message::AddIdConstrained(_) => 25,
+            Message::AddSmartcardKeyConstrained(_) => 26,
+            Message::Extension(_) => 27,
+            Message::ExtensionFailure => 28
+        }
+    }
 }
 
 impl Decode for Message {
@@ -375,7 +458,7 @@ impl Decode for Message {
 
 impl Encode for Message {
     fn encoded_len(&self) -> ssh_encoding::Result<usize> {
-        let command_id = 1;
+        let message_id_len = 1;
         let payload_len = match self {
             Self::Failure => 0,
             Self::Success => 0,
@@ -390,25 +473,29 @@ impl Encode for Message {
                 }
 
                 lengths.checked_sum()?
-            }
-            Self::SignResponse(response) => response.encoded_len()? + 4,
-            _ => todo!(),
+            },
+            Self::SignRequest(request) => request.encoded_len()?,
+            Self::SignResponse(response) => response.encoded_len_prefixed()?,
+            Self::AddIdentity(identity) => identity.encoded_len()?,
+            Self::RemoveIdentity(identity) => identity.encoded_len()?,
+            Self::RemoveAllIdentities => 0,
+            Self::AddSmartcardKey(key) => key.encoded_len()?,
+            Self::RemoveSmartcardKey(key) => key.encoded_len()?,
+            Self::Lock(passphrase) => passphrase.encoded_len()?,
+            Self::Unlock(passphrase) => passphrase.encoded_len()?,
+            Self::AddIdConstrained(key) => key.encoded_len()?,
+            Self::AddSmartcardKeyConstrained(key) => key.encoded_len()?,
+            Self::Extension(extension) => extension.encoded_len()?,
+            Self::ExtensionFailure => 0
         };
 
-        [command_id, payload_len].checked_sum()
+        [message_id_len, payload_len].checked_sum()
     }
 
     fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
-        let command_id: u8 = match self {
-            Self::Failure => 5,
-            Self::Success => 6,
-            Self::RequestIdentities => 11,
-            Self::IdentitiesAnswer(_) => 12,
-            Self::SignResponse(_) => 14,
-            _ => todo!(),
-        };
+        let message_id: u8 = self.message_id();
+        message_id.encode(writer)?;
 
-        command_id.encode(writer)?;
         match self {
             Self::Failure => {}
             Self::Success => {}
@@ -419,10 +506,19 @@ impl Encode for Message {
                     id.encode(writer)?;
                 }
             }
-            Self::SignResponse(response) => {
-                response.encode_prefixed(writer)?;
-            }
-            _ => todo!(),
+            Self::SignRequest(request) => request.encode(writer)?,
+            Self::SignResponse(response) => response.encode_prefixed(writer)?,
+            Self::AddIdentity(identity) => identity.encode(writer)?,
+            Self::RemoveIdentity(identity) => identity.encode(writer)?,
+            Self::RemoveAllIdentities => {},
+            Self::AddSmartcardKey(key) => key.encode(writer)?,
+            Self::RemoveSmartcardKey(key) => key.encode(writer)?,
+            Self::Lock(passphrase) => passphrase.encode(writer)?,
+            Self::Unlock(passphrase) => passphrase.encode(writer)?,
+            Self::AddIdConstrained(identity) => identity.encode(writer)?,
+            Self::AddSmartcardKeyConstrained(key) => key.encode(writer)?,
+            Self::Extension(extension) => extension.encode(writer)?,
+            Self::ExtensionFailure => {},
         };
 
         Ok(())


### PR DESCRIPTION
This change fixes a few issues on the RustCrypto branch, and introduces `Encode` trait implementations for the remaining types:

- Encoding for `SignRequest` messages was fixed to correctly encode the pubkey length in the payload.
- Fixes encoding of `KeyConstraint`
  - In this case, the encoder was referencing the `Unparsed` object directly, rather than the inner `Vec<u8>`
- Adds `Encode` trait implementations for `RemoveIdentity`,`SmartcardKey`, `AddSmartcardKeyConstrained`, `Extension`