### PR TITLE
Disallow using unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_debug_implementations)]
+#![deny(unsafe_code)]
 
 pub mod proto;
 


### PR DESCRIPTION
Using unsafe blocks makes the fuzzer use more resources.

See: https://github.com/wiktor-k/ssh-agent-lib/pull/38