### PR TITLE
Split `Message` into `Request` and `Response`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ subtle = { version = "2", default-features = false }
 
 [features]
 default = ["agent"]
-agent = ["futures", "log", "tokio", "tokio-util", "async-trait"]
+codec = ["tokio-util"]
+agent = ["futures", "log", "tokio", "async-trait", "codec"]
 
 [[example]]
 name = "key_storage"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ use tokio::net::UnixListener as Listener;
 use ssh_agent_lib::agent::NamedPipeListener as Listener;
 
 use ssh_agent_lib::agent::{Session, Agent};
-use ssh_agent_lib::proto::message::Message;
+use ssh_agent_lib::proto::message::{Request, Response};
 use ssh_key::{Algorithm, Signature};
 
 #[derive(Default)]
@@ -27,17 +27,17 @@ struct MyAgent;
 
 #[ssh_agent_lib::async_trait]
 impl Session for MyAgent {
-    async fn handle(&mut self, message: Message) -> Result<Message, Box<dyn std::error::Error>> {
+    async fn handle(&mut self, message: Request) -> Result<Response, Box<dyn std::error::Error>> {
         match message {
-            Message::SignRequest(request) => {
+            Request::SignRequest(request) => {
                 // get the signature by signing `request.data`
                 let signature = vec![];
-                Ok(Message::SignResponse(Signature::new(
+                Ok(Response::SignResponse(Signature::new(
                         Algorithm::new("algorithm")?,
                         signature,
                   )?))
             },
-            _ => Ok(Message::Failure),
+            _ => Ok(Response::Failure),
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ use tokio::net::UnixListener as Listener;
 use ssh_agent_lib::agent::NamedPipeListener as Listener;
 
 use ssh_agent_lib::agent::{Session, Agent};
-use ssh_agent_lib::proto::message::{Request, Response};
+use ssh_agent_lib::proto::{Identity, SignRequest};
 use ssh_key::{Algorithm, Signature};
 
 #[derive(Default)]
@@ -27,18 +27,17 @@ struct MyAgent;
 
 #[ssh_agent_lib::async_trait]
 impl Session for MyAgent {
-    async fn handle(&mut self, message: Request) -> Result<Response, Box<dyn std::error::Error>> {
-        match message {
-            Request::SignRequest(request) => {
-                // get the signature by signing `request.data`
-                let signature = vec![];
-                Ok(Response::SignResponse(Signature::new(
-                        Algorithm::new("algorithm")?,
-                        signature,
-                  )?))
-            },
-            _ => Ok(Response::Failure),
-        }
+    async fn request_identities(&mut self) -> Result<Vec<Identity>, Box<dyn std::error::Error>> {
+        Ok(vec![ /* public keys that this agent knows of */ ])
+    }
+
+    async fn sign(&mut self, request: SignRequest) -> Result<Signature, Box<dyn std::error::Error>> {
+        // get the signature by signing `request.data`
+        let signature = vec![];
+        Ok(Signature::new(
+             Algorithm::new("algorithm")?,
+             signature,
+        )?)
     }
 }
 

--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use log::info;
 use rsa::pkcs1v15::SigningKey;
 use rsa::sha2::{Sha256, Sha512};
 use rsa::signature::{RandomizedSigner, SignatureEncoding};
@@ -141,7 +142,7 @@ impl Session for KeyStorage {
             });
             Ok(())
         } else {
-            eprintln!("Unsupported key type: {:#?}", identity.credential);
+            info!("Unsupported key type: {:#?}", identity.credential);
             Ok(())
         }
     }
@@ -154,12 +155,12 @@ impl Session for KeyStorage {
             identity,
             constraints,
         } = identity;
-        eprintln!("Would use these constraints: {constraints:#?}");
+        info!("Would use these constraints: {constraints:#?}");
         for constraint in constraints {
             if let KeyConstraint::Extension(name, mut details) = constraint {
                 if name == "restrict-destination-v00@openssh.com" {
                     if let Ok(destination_constraint) = details.parse::<SessionBind>() {
-                        eprintln!("Destination constraint: {destination_constraint:?}");
+                        info!("Destination constraint: {destination_constraint:?}");
                     }
                 }
                 if let Credential::Key { privkey, comment } = identity.credential.clone() {
@@ -188,7 +189,7 @@ impl Session for KeyStorage {
         &mut self,
         key: SmartcardKey,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        println!("Adding smartcard key: {key:?}");
+        info!("Adding smartcard key: {key:?}");
 
         Ok(())
     }
@@ -197,16 +198,16 @@ impl Session for KeyStorage {
         &mut self,
         key: AddSmartcardKeyConstrained,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        println!("Adding smartcard key with constraints: {key:?}");
+        info!("Adding smartcard key with constraints: {key:?}");
         Ok(())
     }
     async fn lock(&mut self, pwd: String) -> Result<(), Box<dyn std::error::Error>> {
-        println!("Locked with password: {pwd:?}");
+        info!("Locked with password: {pwd:?}");
         Ok(())
     }
 
     async fn unlock(&mut self, pwd: String) -> Result<(), Box<dyn std::error::Error>> {
-        println!("Unlocked with password: {pwd:?}");
+        info!("Unlocked with password: {pwd:?}");
         Ok(())
     }
 
@@ -214,10 +215,10 @@ impl Session for KeyStorage {
         &mut self,
         mut extension: Extension,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        eprintln!("Extension: {extension:?}");
+        info!("Extension: {extension:?}");
         if extension.name == "session-bind@openssh.com" {
             let bind = extension.details.parse::<SessionBind>()?;
-            eprintln!("Bind: {bind:?}");
+            info!("Bind: {bind:?}");
         }
         Ok(())
     }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,8 +15,8 @@ ssh-encoding = "0.2.0"
 path = ".."
 
 [[bin]]
-name = "message_decode"
-path = "fuzz_targets/message_decode.rs"
+name = "request_decode"
+path = "fuzz_targets/request_decode.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/request_decode.rs
+++ b/fuzz/fuzz_targets/request_decode.rs
@@ -1,9 +1,9 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use ssh_agent_lib::proto::message::Message;
+use ssh_agent_lib::proto::message::Request;
 use ssh_encoding::Decode;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = Message::decode(&mut &data[..]);
+    let _ = Request::decode(&mut &data[..]);
 });

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,84 @@
+use std::marker::PhantomData;
+use std::mem::size_of;
+
+use byteorder::{BigEndian, ReadBytesExt};
+use ssh_encoding::{Decode, Encode};
+use tokio_util::bytes::{Buf, BufMut, BytesMut};
+use tokio_util::codec::{Decoder, Encoder};
+
+use super::error::AgentError;
+use super::proto::ProtoError;
+
+/// SSH framing codec.
+///
+/// This codec first reads an `u32` which indicates the length of the incoming
+/// message. Then decodes the message using specified `Input` type.
+///
+/// The reverse transformation which appends the length of the encoded data
+/// is also implemented for the given `Output` type.
+#[derive(Debug)]
+pub struct Codec<Input, Output>(PhantomData<Input>, PhantomData<Output>)
+where
+    Input: Decode,
+    Output: Encode,
+    AgentError: From<Input::Error>;
+
+impl<Input, Output> Default for Codec<Input, Output>
+where
+    Input: Decode,
+    Output: Encode,
+    AgentError: From<Input::Error>,
+{
+    fn default() -> Self {
+        Self(PhantomData, PhantomData)
+    }
+}
+
+impl<Input, Output> Decoder for Codec<Input, Output>
+where
+    Input: Decode,
+    Output: Encode,
+    AgentError: From<Input::Error>,
+{
+    type Item = Input;
+    type Error = AgentError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let mut bytes = &src[..];
+
+        if bytes.len() < size_of::<u32>() {
+            return Ok(None);
+        }
+
+        let length = bytes.read_u32::<BigEndian>()? as usize;
+
+        if bytes.len() < length {
+            return Ok(None);
+        }
+
+        let message = Self::Item::decode(&mut bytes)?;
+        src.advance(size_of::<u32>() + length);
+        Ok(Some(message))
+    }
+}
+
+impl<Input, Output> Encoder<Output> for Codec<Input, Output>
+where
+    Input: Decode,
+    Output: Encode,
+    AgentError: From<Input::Error>,
+{
+    type Error = AgentError;
+
+    fn encode(&mut self, item: Output, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let mut bytes = Vec::new();
+
+        let len = item.encoded_len().unwrap() as u32;
+        len.encode(&mut bytes).map_err(ProtoError::SshEncoding)?;
+
+        item.encode(&mut bytes).map_err(ProtoError::SshEncoding)?;
+        dst.put(&*bytes);
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod proto;
 
 #[cfg(feature = "agent")]
 pub mod agent;
+#[cfg(feature = "codec")]
+pub mod codec;
 pub mod error;
 
 #[cfg(feature = "agent")]

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,17 +1,29 @@
 use std::path::PathBuf;
 
 use rstest::rstest;
-use ssh_agent_lib::proto::Message;
+use ssh_agent_lib::proto::{Request, Response};
 use ssh_encoding::{Decode, Encode};
 use testresult::TestResult;
 
-#[rstest]
-fn roundtrip(#[files("tests/messages/*.bin")] path: PathBuf) -> TestResult {
+fn roundtrip<T: Decode + Encode>(path: PathBuf) -> TestResult
+where
+    T::Error: std::fmt::Display,
+{
     let serialized = std::fs::read(path)?;
     let mut bytes: &[u8] = &serialized;
-    let message = Message::decode(&mut bytes)?;
+    let message = T::decode(&mut bytes)?;
     let mut out = vec![];
     message.encode(&mut out)?;
     assert_eq!(serialized, out);
     Ok(())
+}
+
+#[rstest]
+fn roundtrip_requests(#[files("tests/messages/req-*.bin")] path: PathBuf) -> TestResult {
+    roundtrip::<Request>(path)
+}
+
+#[rstest]
+fn roundtrip_responses(#[files("tests/messages/resp-*.bin")] path: PathBuf) -> TestResult {
+    roundtrip::<Response>(path)
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -5,13 +5,14 @@ use ssh_agent_lib::proto::{Request, Response};
 use ssh_encoding::{Decode, Encode};
 use testresult::TestResult;
 
-fn roundtrip<T: Decode + Encode>(path: PathBuf) -> TestResult
+fn roundtrip<T: Decode + Encode + std::fmt::Debug>(path: PathBuf) -> TestResult
 where
     T::Error: std::fmt::Display,
 {
     let serialized = std::fs::read(path)?;
     let mut bytes: &[u8] = &serialized;
     let message = T::decode(&mut bytes)?;
+    eprintln!("Message: {message:#?}");
     let mut out = vec![];
     message.encode(&mut out)?;
     assert_eq!(serialized, out);

--- a/tests/sign-and-verify.sh
+++ b/tests/sign-and-verify.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 rm -rf ssh-agent.sock Cargo.toml.sig id_rsa id_rsa.pub agent.pub ca_user_key ca_user_key.pub id_rsa-cert.pub
-cargo run --example key_storage &
+RUST_LOG=info cargo run --example key_storage &
 
 while [ ! -e ssh-agent.sock ]; do
   echo "Waiting for ssh-agent.sock"


### PR DESCRIPTION
As it says on the tin.

It makes the type system check if we're not sending requests as replies in the agent and vice versa.

I think some cleanup is still needed (e.g. not using `message` as a variable name, or duplication in `Request::SignRequest`) but I'm filing it earlier to gather your feedback :)