### PR TITLE
Document vast majority of protocol messages

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,3 +1,5 @@
+//! Traits for implementing custom SSH agents
+
 use std::fmt;
 use std::io;
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,3 +1,5 @@
+//! SSH agent protocol framing codec
+
 use std::marker::PhantomData;
 use std::mem::size_of;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//! SSH agent errors
+
 use std::io;
 
 use thiserror::Error;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,3 +1,5 @@
+//! SSH agent protocol structures
+
 pub mod error;
 pub mod extension;
 pub mod message;

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -1,3 +1,5 @@
+//! Agent protocol errors.
+
 use std::{io, string};
 
 use thiserror::Error;

--- a/src/proto/extension.rs
+++ b/src/proto/extension.rs
@@ -4,13 +4,14 @@ use ssh_key::{public::KeyData, Signature};
 // Reserved fields are marked with an empty string
 const RESERVED_FIELD: &str = "";
 
-/// session-bind@openssh.com extension
+/// `session-bind@openssh.com` message extension.
 ///
-/// This extension allows a ssh client to bind an agent connection to a
-/// particular SSH session.
+/// This message extension allows an SSH client to bind an
+/// agent connection to a particular SSH session.
 ///
-/// Spec:
-/// <https://github.com/openssh/openssh-portable/blob/cbbdf868bce431a59e2fa36ca244d5739429408d/PROTOCOL.agent#L6>
+/// *Note*: This is an OpenSSH-specific extension to the agent protocol.
+///
+/// Described in [OpenSSH PROTOCOL.agent § 1](https://github.com/openssh/openssh-portable/blob/cbbdf868bce431a59e2fa36ca244d5739429408d/PROTOCOL.agent#L6)
 #[derive(Debug, Clone)]
 pub struct SessionBind {
     pub host_key: KeyData,
@@ -59,6 +60,15 @@ impl Encode for SessionBind {
     }
 }
 
+/// `restrict-destination-v00@openssh.com` key constraint extension.
+///
+/// The key constraint extension supports destination- and forwarding path-
+/// restricted keys. It may be attached as a constraint when keys or
+/// smartcard keys are added to an agent.
+///
+/// *Note*: This is an OpenSSH-specific extension to the agent protocol.
+///
+/// Described in [OpenSSH PROTOCOL.agent § 2](https://github.com/openssh/openssh-portable/blob/cbbdf868bce431a59e2fa36ca244d5739429408d/PROTOCOL.agent#L38)
 #[derive(Debug, Clone)]
 pub struct RestrictDestination {
     pub constraints: Vec<DestinationConstraint>,
@@ -145,6 +155,14 @@ impl Encode for HostTuple {
     }
 }
 
+/// Key destination constraint.
+///
+/// One or more [`DestinationConstraint`]s are included in
+/// the [`RestrictDestination`] key constraint extension.
+///
+/// *Note*: This is an OpenSSH-specific extension to the agent protocol.
+///
+/// Described in [OpenSSH PROTOCOL.agent § 2](https://github.com/openssh/openssh-portable/blob/cbbdf868bce431a59e2fa36ca244d5739429408d/PROTOCOL.agent#L38)
 #[derive(Debug, Clone)]
 pub struct DestinationConstraint {
     pub from: HostTuple,
@@ -181,6 +199,15 @@ impl Encode for DestinationConstraint {
     }
 }
 
+/// Public key specification.
+///
+/// This structure is included in [`DestinationConstraint`],
+/// which in turn is used in the [`RestrictDestination`] key
+/// constraint extension.
+///
+/// *Note*: This is an OpenSSH-specific extension to the agent protocol.
+///
+/// Described in [OpenSSH PROTOCOL.agent § 2](https://github.com/openssh/openssh-portable/blob/cbbdf868bce431a59e2fa36ca244d5739429408d/PROTOCOL.agent#L38)
 #[derive(Debug, Clone)]
 pub struct KeySpec {
     pub keyblob: KeyData,

--- a/src/proto/privatekey.rs
+++ b/src/proto/privatekey.rs
@@ -1,3 +1,5 @@
+//! Types for handling SSH private key data.
+
 use core::fmt;
 
 use ssh_encoding::{Decode, Encode, Reader, Writer};
@@ -80,6 +82,7 @@ impl Encode for EcdsaPrivateKey {
     }
 }
 
+/// Private key data stored within a `Credential` object
 #[derive(Clone)]
 #[non_exhaustive]
 pub enum PrivateKeyData {
@@ -93,6 +96,7 @@ pub enum PrivateKeyData {
     // algorithm that will always encode the full key pair.
     /// Ed25519 key pair.
     Ed25519(Ed25519Keypair),
+
     /// RSA private key.
     Rsa(RsaPrivateKey),
 }

--- a/src/proto/signature.rs
+++ b/src/proto/signature.rs
@@ -1,2 +1,8 @@
+//! Agent protocol signature flag constants.
+
+/// The `SSH_AGENT_RSA_SHA2_256` signature flag, as described in
+/// [draft-miller-ssh-agent-14 § 3.6.1](https://www.ietf.org/archive/id/draft-miller-ssh-agent-14.html#section-3.6.1)
 pub const RSA_SHA2_256: u32 = 0x02;
+/// The `SSH_AGENT_RSA_SHA2_512` signature flag, as described in
+/// [draft-miller-ssh-agent-14 § 3.6.1](https://www.ietf.org/archive/id/draft-miller-ssh-agent-14.html#section-3.6.1)
 pub const RSA_SHA2_512: u32 = 0x04;


### PR DESCRIPTION
This PR adds documentation for the structures in the `proto` module with references back to the agent protocol specification.

I'll come back later and add top-level documentation for these modules.

I've held off on documenting the `agent` module as it's undergoing a bit of renovation at the moment!

I've tried to say as close to the specification with this documentation, but have added some simplifications of the spec in some places, so very open to feedback / nits :^)