### PR TITLE
unused type alias

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -8,5 +8,3 @@ pub use self::error::*;
 pub use self::message::*;
 pub use self::privatekey::*;
 pub use self::signature::*;
-
-pub type MpInt = Vec<u8>;


### PR DESCRIPTION
After the rustcrypto refactor, this type alias was left over