### PR TITLE
Add OpenPGP Card example

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# Ubuntu packages
+UBUNTU_PACKAGES=libpcsclite-dev
+# Windows packages
+WINDOWS_PACKAGES=
+# macOS packages
+MACOS_PACKAGES=

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - run: cargo install --locked just
+      - run: just install-packages
       # If the example doesn't compile the integration test will
       # be stuck. Check for compilation issues earlier to abort the job
       - name: Check if the example compiles

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - run: cargo install --locked just
+      - uses: taiki-e/install-action@just
       - run: just install-packages
       # If the example doesn't compile the integration test will
       # be stuck. Check for compilation issues earlier to abort the job

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wiktor-k/setup-just@v1
+      - run: just install-packages
       - name: Run unit tests
         run: just tests
 
@@ -73,5 +74,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wiktor-k/setup-just@v1
+      - run: just install-packages
       - name: Check for lints
         run: just lints

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: wiktor-k/setup-just@v1
+      - uses: taiki-e/install-action@just
       - run: rustup install nightly
       - run: rustup component add rustfmt --toolchain nightly
       - name: Check formatting
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: wiktor-k/setup-just@v1
+      - uses: taiki-e/install-action@just
       - run: just install-packages
       - name: Run unit tests
         run: just tests
@@ -73,7 +73,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: wiktor-k/setup-just@v1
+      - uses: taiki-e/install-action@just
       - run: just install-packages
       - name: Check for lints
         run: just lints

--- a/.justfile
+++ b/.justfile
@@ -1,4 +1,8 @@
 #!/usr/bin/env -S just --working-directory . --justfile
+# Load project-specific properties from the `.env` file
+
+set dotenv-load := true
+
 # Since this is a first recipe it's being run by default.
 # Faster checks need to be executed first for better UX.  For example
 
@@ -30,6 +34,16 @@ tests:
 # Build docs for this crate only
 docs:
     cargo doc --no-deps
+
+# Installs packages required to build
+[linux]
+install-packages:
+    sudo apt-get install --assume-yes --no-install-recommends $UBUNTU_PACKAGES
+
+[macos]
+[windows]
+install-packages:
+    echo no-op
 
 # Checks for commit messages
 check-commits REFS='main..':

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-timer"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5fa6ed76cb2aa820707b4eb9ec46f42da9ce70b0eafab5e5e34942b38a44d5"
+dependencies = [
+ "libc",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +475,12 @@ dependencies = [
  "humantime",
  "log",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "ff"
@@ -1095,6 +1121,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
+name = "retainer"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8c01a8276c14d0f8d51ebcf8a48f0748f9f73f5f6b29e688126e6a52bcb145"
+dependencies = [
+ "async-lock",
+ "async-timer",
+ "log",
+ "rand",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1219,15 @@ dependencies = [
  "generic-array",
  "pkcs8",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
  "zeroize",
 ]
 
@@ -1288,8 +1335,10 @@ dependencies = [
  "openpgp-card",
  "p256",
  "rand",
+ "retainer",
  "rsa",
  "rstest",
+ "secrecy",
  "service-binding",
  "sha1",
  "signature",
@@ -1552,6 +1601,28 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +153,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -144,6 +171,27 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "card-backend"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3ee3a298842065dc489180c34a4fe4bbbb8643bb422009d79558a099fb42e5"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "card-backend-pcsc"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bb0b707b1b6b058ed93abd70ef65703ed6fd4150d32a0d735b78cfa61cbb35"
+dependencies = [
+ "card-backend",
+ "iso7816-tlv",
+ "log",
+ "pcsc",
+]
 
 [[package]]
 name = "cc"
@@ -162,6 +210,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +232,46 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -188,6 +290,12 @@ name = "const-str"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -505,6 +613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +629,12 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hex-slice"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a308e0214554f07a81d8944abe45f552871c12e3c3c6e7e5d354039a6c4c"
 
 [[package]]
 name = "hmac"
@@ -532,6 +652,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,12 +684,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iso7816-tlv"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7660d28d24a831d690228a275d544654a30f3b167a8e491cf31af5fe5058b546"
+dependencies = [
+ "untrusted",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -594,6 +755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +778,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -686,6 +863,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openpgp-card"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e4e4146cf765e416a6c73e6bef6a4aa4cb12a76d9ef24c8c170eba4e4384ca"
+dependencies = [
+ "card-backend",
+ "chrono",
+ "hex-slice",
+ "log",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +912,25 @@ dependencies = [
  "primeorder",
  "rand_core",
  "sha2",
+]
+
+[[package]]
+name = "pcsc"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ed9d7f816b7d9ce9ddb0062dd2f393b3af31411a95a35411809b4b9116ea08"
+dependencies = [
+ "bitflags",
+ "pcsc-sys",
+]
+
+[[package]]
+name = "pcsc-sys"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09e9ba80f2c4d167f936d27594f7248bca3295921ffbfa44a24b339b6cb7403"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -764,6 +974,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
@@ -1062,11 +1278,14 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "byteorder",
+ "card-backend-pcsc",
+ "clap",
  "const-str",
  "env_logger",
  "futures",
  "hex-literal",
  "log",
+ "openpgp-card",
  "p256",
  "rand",
  "rsa",
@@ -1134,6 +1353,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1251,6 +1476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1498,69 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,5 @@ rstest = "0.18.2"
 openpgp-card = "0.4.2"
 card-backend-pcsc = "0.5.0"
 clap = { version = "4.5.4", features = ["derive"] }
+secrecy = "0.8.0"
+retainer = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ ssh-key = { version = "0.6.6", features = ["p256"] }
 p256 = { version = "0.13.2" }
 const-str = "0.5.7"
 rstest = "0.18.2"
+openpgp-card = "0.4.2"
+card-backend-pcsc = "0.5.0"
+clap = { version = "4.5.4", features = ["derive"] }

--- a/examples/openpgp-card-agent.rs
+++ b/examples/openpgp-card-agent.rs
@@ -14,10 +14,7 @@
 //! - storing PIN for one of the cards: `SSH_AUTH_SOCK=/tmp/sock ssh-add -s 0006:15422467` (the agent will validate the PIN before storing it)
 //! - and that's it! You can use the agent to login to your SSH servers.
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::{sync::Arc, time::Duration};
 
 use card_backend_pcsc::PcscBackend;
 use clap::Parser;
@@ -26,11 +23,13 @@ use openpgp_card::{
     crypto_data::{EccType, PublicKeyMaterial},
     Card, KeyType,
 };
+use retainer::{Cache, CacheExpiration};
+use secrecy::{ExposeSecret, SecretString};
 use service_binding::Binding;
 use ssh_agent_lib::{
     agent::Session,
     error::AgentError,
-    proto::{Identity, SignRequest, SmartcardKey},
+    proto::{AddSmartcardKeyConstrained, Identity, KeyConstraint, SignRequest, SmartcardKey},
     Agent,
 };
 use ssh_key::{
@@ -39,9 +38,17 @@ use ssh_key::{
 };
 use testresult::TestResult;
 
-#[derive(Default)]
 struct CardAgent {
-    pwds: Arc<Mutex<HashMap<String, String>>>,
+    pwds: Arc<Cache<String, SecretString>>,
+}
+
+impl CardAgent {
+    pub fn new() -> Self {
+        let pwds: Arc<Cache<String, SecretString>> = Arc::new(Default::default());
+        let clone = Arc::clone(&pwds);
+        tokio::spawn(async move { clone.monitor(4, 0.25, Duration::from_secs(3)).await });
+        Self { pwds }
+    }
 }
 
 impl Agent for CardAgent {
@@ -53,7 +60,74 @@ impl Agent for CardAgent {
 }
 
 struct CardSession {
-    pwds: Arc<Mutex<HashMap<String, String>>>,
+    pwds: Arc<Cache<String, SecretString>>,
+}
+
+impl CardSession {
+    async fn handle_sign(
+        &self,
+        request: SignRequest,
+    ) -> Result<ssh_key::Signature, Box<dyn std::error::Error + Send + Sync>> {
+        let cards = PcscBackend::cards(None).map_err(AgentError::other)?;
+        for card in cards {
+            let mut card = Card::new(card?)?;
+            let mut tx = card.transaction()?;
+            let ident = tx.application_identifier()?.ident();
+            if let PublicKeyMaterial::E(e) = tx.public_key(KeyType::Authentication)? {
+                if let AlgorithmAttributes::Ecc(ecc) = e.algo() {
+                    if ecc.ecc_type() == EccType::EdDSA {
+                        let pubkey = KeyData::Ed25519(Ed25519PublicKey(e.data().try_into()?));
+                        if pubkey == request.pubkey {
+                            let pin = self.pwds.get(&ident).await;
+                            return if let Some(pin) = pin {
+                                tx.verify_pw1_user(pin.expose_secret().as_bytes())?;
+                                let signature = tx.internal_authenticate(request.data.clone())?;
+
+                                Ok(Signature::new(Algorithm::Ed25519, signature)?)
+                            } else {
+                                // no pin saved, use "ssh-add -s ..."
+                                Err(std::io::Error::other("no pin saved").into())
+                            };
+                        }
+                    }
+                }
+            }
+        }
+        Err(std::io::Error::other("no applicable card found").into())
+    }
+
+    async fn handle_add_smartcard_key(
+        &mut self,
+        key: SmartcardKey,
+        expiration: impl Into<CacheExpiration>,
+    ) -> Result<(), AgentError> {
+        match PcscBackend::cards(None) {
+            Ok(cards) => {
+                let card_pin_matches = cards
+                    .flat_map(|card| {
+                        let mut card = Card::new(card?)?;
+                        let mut tx = card.transaction()?;
+                        let ident = tx.application_identifier()?.ident();
+                        if ident == key.id {
+                            tx.verify_pw1_user(key.pin.as_bytes())?;
+                            Ok::<_, Box<dyn std::error::Error>>(true)
+                        } else {
+                            Ok(false)
+                        }
+                    })
+                    .any(|x| x);
+                if card_pin_matches {
+                    self.pwds.insert(key.id, key.pin.into(), expiration).await;
+                    Ok(())
+                } else {
+                    Err(AgentError::IO(std::io::Error::other(
+                        "Card/PIN combination is not valid",
+                    )))
+                }
+            }
+            Err(error) => Err(AgentError::other(error)),
+        }
+    }
 }
 
 #[ssh_agent_lib::async_trait]
@@ -87,70 +161,32 @@ impl Session for CardSession {
     }
 
     async fn add_smartcard_key(&mut self, key: SmartcardKey) -> Result<(), AgentError> {
-        match PcscBackend::cards(None) {
-            Ok(cards) => {
-                let card_pin_matches = cards
-                    .flat_map(|card| {
-                        let mut card = Card::new(card?)?;
-                        let mut tx = card.transaction()?;
-                        let ident = tx.application_identifier()?.ident();
-                        if ident == key.id {
-                            tx.verify_pw1_user(key.pin.as_bytes())?;
-                            Ok::<_, Box<dyn std::error::Error>>(true)
-                        } else {
-                            Ok(false)
-                        }
-                    })
-                    .any(|x| x);
-                if card_pin_matches {
-                    self.pwds
-                        .lock()
-                        .expect("lock not to be poisoned")
-                        .insert(key.id, key.pin);
-                    Ok(())
-                } else {
-                    Err(AgentError::IO(std::io::Error::other(
-                        "Card/PIN combination is not valid",
-                    )))
-                }
-            }
-            Err(error) => Err(AgentError::other(error)),
+        self.handle_add_smartcard_key(key, CacheExpiration::none())
+            .await
+    }
+
+    async fn add_smartcard_key_constrained(
+        &mut self,
+        key: AddSmartcardKeyConstrained,
+    ) -> Result<(), AgentError> {
+        if key.constraints.len() > 1 {
+            return Err(AgentError::other(std::io::Error::other(
+                "Only one lifetime constraint supported.",
+            )));
         }
+        let expiration_in_seconds = if let KeyConstraint::Lifetime(seconds) = key.constraints[0] {
+            Duration::from_secs(seconds as u64)
+        } else {
+            return Err(AgentError::other(std::io::Error::other(
+                "Only one lifetime constraint supported.",
+            )));
+        };
+        self.handle_add_smartcard_key(key.key, expiration_in_seconds)
+            .await
     }
 
     async fn sign(&mut self, request: SignRequest) -> Result<Signature, AgentError> {
-        let cards = PcscBackend::cards(None).map_err(AgentError::other)?;
-        cards
-            .flat_map(|card| -> Result<_, Box<dyn std::error::Error>> {
-                let mut card = Card::new(card?)?;
-                let mut tx = card.transaction()?;
-                let ident = tx.application_identifier()?.ident();
-                if let PublicKeyMaterial::E(e) = tx.public_key(KeyType::Authentication)? {
-                    if let AlgorithmAttributes::Ecc(ecc) = e.algo() {
-                        if ecc.ecc_type() == EccType::EdDSA {
-                            let pubkey = KeyData::Ed25519(Ed25519PublicKey(e.data().try_into()?));
-                            if pubkey == request.pubkey {
-                                let pwds = self.pwds.lock().expect("mutex not to be poisoned");
-                                let pin = pwds.get(&ident);
-                                return if let Some(pin) = pin {
-                                    tx.verify_pw1_user(pin.as_bytes())?;
-                                    let signature =
-                                        tx.internal_authenticate(request.data.clone())?;
-
-                                    Ok(Signature::new(Algorithm::Ed25519, signature))
-                                } else {
-                                    // no pin saved, use "ssh-add -s ..."
-                                    Err(std::io::Error::other("no pin saved").into())
-                                };
-                            }
-                        }
-                    }
-                }
-                Err(std::io::Error::other("no applicable card found").into())
-            })
-            .flatten()
-            .next()
-            .ok_or(std::io::Error::other("no applicable card found").into())
+        self.handle_sign(request).await.map_err(AgentError::Other)
     }
 }
 
@@ -162,7 +198,9 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> TestResult {
+    env_logger::init();
+
     let args = Args::parse();
-    CardAgent::default().bind(args.host.try_into()?).await?;
+    CardAgent::new().bind(args.host.try_into()?).await?;
     Ok(())
 }

--- a/examples/openpgp-card-agent.rs
+++ b/examples/openpgp-card-agent.rs
@@ -1,0 +1,168 @@
+//! OpenPGP Card SSH Agent
+//!
+//! Implements an SSH agent which forwards cryptographic operations to
+//! an OpenPGP Card device (such as Yubikey, Nitrokey etc).
+//! The PIN is stored in memory for the duration of the agent session.
+//! This agent supports only ed25519 authentication subkeys.
+//! To provision the token use [OpenPGP Card Tools](https://codeberg.org/openpgp-card/openpgp-card-tools/#generate-keys-on-the-card).
+//! Due to the use of PC/SC the agent requires pcsclite on Linux but no other libs
+//! on Windows and macOS as it will utilize built-in smartcard services.
+//!
+//! The typical session:
+//! - starting the SSH agent: `cargo run --example openpgp-card-agent -- -H unix:///tmp/sock`
+//! - listing available cards: `SSH_AUTH_SOCK=/tmp/sock ssh-add -L` (this will display the card ident used in the next step)
+//! - storing PIN for one of the cards: `SSH_AUTH_SOCK=/tmp/sock ssh-add -s 0006:15422467` (the agent will validate the PIN before storing it)
+//! - and that's it! You can use the agent to login to your SSH servers.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use card_backend_pcsc::PcscBackend;
+use clap::Parser;
+use openpgp_card::{
+    algorithm::AlgorithmAttributes,
+    crypto_data::{EccType, PublicKeyMaterial},
+    Card, KeyType,
+};
+use service_binding::Binding;
+use ssh_agent_lib::{
+    agent::Session,
+    error::AgentError,
+    proto::{Identity, SignRequest, SmartcardKey},
+    Agent,
+};
+use ssh_key::{
+    public::{Ed25519PublicKey, KeyData},
+    Algorithm, Signature,
+};
+use testresult::TestResult;
+
+#[derive(Default)]
+struct CardAgent {
+    pwds: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl Agent for CardAgent {
+    fn new_session(&mut self) -> impl Session {
+        CardSession {
+            pwds: Arc::clone(&self.pwds),
+        }
+    }
+}
+
+struct CardSession {
+    pwds: Arc<Mutex<HashMap<String, String>>>,
+}
+
+#[ssh_agent_lib::async_trait]
+impl Session for CardSession {
+    async fn request_identities(&mut self) -> Result<Vec<Identity>, AgentError> {
+        Ok(if let Ok(cards) = PcscBackend::cards(None) {
+            cards
+                .flat_map(|card| {
+                    let mut card = Card::new(card?)?;
+                    let mut tx = card.transaction()?;
+                    let ident = tx.application_identifier()?.ident();
+                    if let PublicKeyMaterial::E(e) = tx.public_key(KeyType::Authentication)? {
+                        if let AlgorithmAttributes::Ecc(ecc) = e.algo() {
+                            if ecc.ecc_type() == EccType::EdDSA {
+                                return Ok::<_, Box<dyn std::error::Error>>(Some(Identity {
+                                    pubkey: KeyData::Ed25519(Ed25519PublicKey(
+                                        e.data().try_into()?,
+                                    )),
+                                    comment: ident,
+                                }));
+                            }
+                        }
+                    }
+                    Ok(None)
+                })
+                .flatten()
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        })
+    }
+
+    async fn add_smartcard_key(&mut self, key: SmartcardKey) -> Result<(), AgentError> {
+        match PcscBackend::cards(None) {
+            Ok(cards) => {
+                let card_pin_matches = cards
+                    .flat_map(|card| {
+                        let mut card = Card::new(card?)?;
+                        let mut tx = card.transaction()?;
+                        let ident = tx.application_identifier()?.ident();
+                        if ident == key.id {
+                            tx.verify_pw1_user(key.pin.as_bytes())?;
+                            Ok::<_, Box<dyn std::error::Error>>(true)
+                        } else {
+                            Ok(false)
+                        }
+                    })
+                    .any(|x| x);
+                if card_pin_matches {
+                    self.pwds
+                        .lock()
+                        .expect("lock not to be poisoned")
+                        .insert(key.id, key.pin);
+                    Ok(())
+                } else {
+                    Err(AgentError::IO(std::io::Error::other(
+                        "Card/PIN combination is not valid",
+                    )))
+                }
+            }
+            Err(error) => Err(AgentError::other(error)),
+        }
+    }
+
+    async fn sign(&mut self, request: SignRequest) -> Result<Signature, AgentError> {
+        let cards = PcscBackend::cards(None).map_err(AgentError::other)?;
+        cards
+            .flat_map(|card| -> Result<_, Box<dyn std::error::Error>> {
+                let mut card = Card::new(card?)?;
+                let mut tx = card.transaction()?;
+                let ident = tx.application_identifier()?.ident();
+                if let PublicKeyMaterial::E(e) = tx.public_key(KeyType::Authentication)? {
+                    if let AlgorithmAttributes::Ecc(ecc) = e.algo() {
+                        if ecc.ecc_type() == EccType::EdDSA {
+                            let pubkey = KeyData::Ed25519(Ed25519PublicKey(e.data().try_into()?));
+                            if pubkey == request.pubkey {
+                                let pwds = self.pwds.lock().expect("mutex not to be poisoned");
+                                let pin = pwds.get(&ident);
+                                return if let Some(pin) = pin {
+                                    tx.verify_pw1_user(pin.as_bytes())?;
+                                    let signature =
+                                        tx.internal_authenticate(request.data.clone())?;
+
+                                    Ok(Signature::new(Algorithm::Ed25519, signature))
+                                } else {
+                                    // no pin saved, use "ssh-add -s ..."
+                                    Err(std::io::Error::other("no pin saved").into())
+                                };
+                            }
+                        }
+                    }
+                }
+                Err(std::io::Error::other("no applicable card found").into())
+            })
+            .flatten()
+            .next()
+            .ok_or(std::io::Error::other("no applicable card found").into())
+    }
+}
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[clap(short = 'H', long)]
+    host: Binding,
+}
+
+#[tokio::main]
+async fn main() -> TestResult {
+    let args = Args::parse();
+    CardAgent::default().bind(args.host.try_into()?).await?;
+    Ok(())
+}


### PR DESCRIPTION
I've added a more elaborate example of an SSH agent. Actually this is a code that I'm planning to use (semi-)daily.

It has a couple of limitations, first of all it supports ed25519 keys only but I think it's a good idea to show how agents can be built and also serves as a validation of our API.