### PR TITLE
`Extension::parse` doesn't require mutability

### DIFF
--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -200,10 +200,7 @@ impl Session for KeyStorage {
         Ok(())
     }
 
-    async fn extension(
-        &mut self,
-        mut extension: Extension,
-    ) -> Result<Option<Extension>, AgentError> {
+    async fn extension(&mut self, extension: Extension) -> Result<Option<Extension>, AgentError> {
         info!("Extension: {extension:?}");
 
         match extension.name.as_str() {

--- a/src/proto/message.rs
+++ b/src/proto/message.rs
@@ -557,7 +557,7 @@ impl Extension {
     /// If there is a mismatch between the extension name
     /// and the [`MessageExtension::NAME`], this method
     /// will return [`None`]
-    pub fn parse_message<T>(&mut self) -> std::result::Result<Option<T>, <T as Decode>::Error>
+    pub fn parse_message<T>(&self) -> std::result::Result<Option<T>, <T as Decode>::Error>
     where
         T: MessageExtension + Decode,
     {
@@ -638,7 +638,7 @@ pub struct Unparsed(pub Vec<u8>);
 
 impl Unparsed {
     /// Decode unparsed bytes as SSH structures.
-    pub fn parse<T>(&mut self) -> std::result::Result<T, <T as Decode>::Error>
+    pub fn parse<T>(&self) -> std::result::Result<T, <T as Decode>::Error>
     where
         T: Decode,
     {


### PR DESCRIPTION
Because payload has already been read from the wire and copied in the `Unparsed` structure, the extension doesn't need to be mutable to be deserialized.