### PR TITLE
Remove unused `&mut self` in key constraint extension parsing

### DIFF
--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -151,7 +151,7 @@ impl Session for KeyStorage {
         } = identity;
         info!("Would use these constraints: {constraints:#?}");
         for constraint in constraints {
-            if let KeyConstraint::Extension(mut extension) = constraint {
+            if let KeyConstraint::Extension(extension) = constraint {
                 if let Some(destination) =
                     extension.parse_key_constraint::<RestrictDestination>()?
                 {

--- a/src/proto/message.rs
+++ b/src/proto/message.rs
@@ -589,9 +589,7 @@ impl Extension {
     /// If there is a mismatch between the extension name
     /// and the [`KeyConstraintExtension::NAME`], this method
     /// will return [`None`]
-    pub fn parse_key_constraint<T>(
-        &mut self,
-    ) -> std::result::Result<Option<T>, <T as Decode>::Error>
+    pub fn parse_key_constraint<T>(&self) -> std::result::Result<Option<T>, <T as Decode>::Error>
     where
         T: KeyConstraintExtension + Decode,
     {


### PR DESCRIPTION
Following on from #58, I noticed that key constraint extensions don't need `&mut self` in method calls either.

Thanks for the pickup @baloo!