### PR TITLE
WIP: Add ClientInfo type to ListeningSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "windows",
 ]
 
 [[package]]
@@ -1207,6 +1208,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,7 +1251,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1241,17 +1271,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -1262,9 +1293,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1274,9 +1305,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1286,9 +1317,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1298,9 +1335,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1310,9 +1347,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1322,9 +1359,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1334,9 +1371,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,13 @@ thiserror = "1.0.58"
 #uuid = { version = "1.8.0", features = ["v4"] }
 subtle = { version = "2", default-features = false }
 
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.54"
+features = [
+    "Win32_Foundation",
+    "Win32_System_Pipes",
+]
+
 [features]
 default = ["agent"]
 codec = ["tokio-util"]

--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -9,7 +9,7 @@ use rsa::BigUint;
 use sha1::Sha1;
 #[cfg(windows)]
 use ssh_agent_lib::agent::NamedPipeListener as Listener;
-use ssh_agent_lib::agent::Session;
+use ssh_agent_lib::agent::{ListeningSocket, Session};
 use ssh_agent_lib::error::AgentError;
 use ssh_agent_lib::proto::extension::{QueryResponse, RestrictDestination, SessionBind};
 use ssh_agent_lib::proto::{
@@ -235,7 +235,10 @@ impl KeyStorageAgent {
 }
 
 impl Agent for KeyStorageAgent {
-    fn new_session(&mut self) -> impl Session {
+    fn new_session<S>(&mut self, _socket: &S::Stream) -> impl Session
+    where
+        S: ListeningSocket + std::fmt::Debug + Send,
+    {
         KeyStorage {
             identities: Arc::clone(&self.identities),
         }

--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -235,10 +235,11 @@ impl KeyStorageAgent {
 }
 
 impl Agent for KeyStorageAgent {
-    fn new_session<S>(&mut self, _socket: &S::Stream) -> impl Session
+    fn new_session<S>(&mut self, _socket: &S::Stream, client_info: &S::ClientInfo) -> impl Session
     where
         S: ListeningSocket + std::fmt::Debug + Send,
     {
+        println!("New connection from client: {:?}", client_info);
         KeyStorage {
             identities: Arc::clone(&self.identities),
         }

--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -235,11 +235,14 @@ impl KeyStorageAgent {
 }
 
 impl Agent for KeyStorageAgent {
-    fn new_session<S>(&mut self, _socket: &S::Stream, client_info: &S::ClientInfo) -> impl Session
+    fn new_session<S>(&mut self, socket: &S::Stream) -> impl Session
     where
         S: ListeningSocket + std::fmt::Debug + Send,
     {
-        println!("New connection from client: {:?}", client_info);
+        if let Ok(client_info) = S::client_info(socket) {
+            println!("New connection from client: {:?}", client_info);
+        }
+        
         KeyStorage {
             identities: Arc::clone(&self.identities),
         }

--- a/src/agent/listener.rs
+++ b/src/agent/listener.rs
@@ -1,0 +1,149 @@
+//! Traits for SSH agent sockets
+
+use std::fmt;
+use std::io;
+use std::net;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncRead, AsyncWrite};
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+#[cfg(unix)]
+use tokio::net::{unix::SocketAddr as UnixSocketAddr, unix::UCred, UnixListener, UnixStream};
+use tokio::net::{TcpListener, TcpStream};
+#[cfg(windows)]
+use windows::{
+    Win32::Foundation::HANDLE,
+    Win32::System::Pipes::{GetNamedPipeClientProcessId, GetNamedPipeClientSessionId},
+};
+
+/// Type representing a socket that asynchronously returns a list of streams.
+#[async_trait]
+pub trait ListeningSocket {
+    /// Stream type that represents an accepted socket.
+    type Stream: fmt::Debug + AsyncRead + AsyncWrite + Send + Unpin + 'static;
+
+    /// Type that represents a client to an accepted socket.
+    type ClientInfo: fmt::Debug + Send + Unpin + 'static;
+
+    /// Waits until a client connects and returns connected stream.
+    async fn accept(&mut self) -> io::Result<Self::Stream>;
+
+    /// Given an accepted socket, return platform-specific
+    /// information about the client
+    fn client_info(stream: &Self::Stream) -> io::Result<Self::ClientInfo>;
+}
+
+/// Type representing a client to a Unix Socket
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct UnixClientInfo {
+    /// The socket address of the remote half of this connection.
+    pub socket_addr: UnixSocketAddr,
+
+    /// Effective credentials of the process which connected
+    /// to the socket
+    pub credentials: UCred,
+}
+
+#[cfg(unix)]
+#[async_trait]
+impl ListeningSocket for UnixListener {
+    type Stream = UnixStream;
+    type ClientInfo = UnixClientInfo;
+
+    async fn accept(&mut self) -> io::Result<Self::Stream> {
+        UnixListener::accept(self).await.map(|(s, _addr)| s)
+    }
+
+    fn client_info(stream: &Self::Stream) -> io::Result<Self::ClientInfo> {
+        Ok(UnixClientInfo {
+            socket_addr: stream.peer_addr()?,
+            credentials: stream.peer_cred()?,
+        })
+    }
+}
+
+/// Type representing a client to a TCP socket
+#[derive(Debug)]
+pub struct TcpClientInfo(pub net::SocketAddr);
+
+#[async_trait]
+impl ListeningSocket for TcpListener {
+    type Stream = TcpStream;
+    type ClientInfo = TcpClientInfo;
+
+    async fn accept(&mut self) -> io::Result<Self::Stream> {
+        TcpListener::accept(self).await.map(|(s, _addr)| s)
+    }
+
+    fn client_info(stream: &Self::Stream) -> io::Result<Self::ClientInfo> {
+        Ok(TcpClientInfo(stream.peer_addr()?))
+    }
+}
+
+/// Listener for Windows Named Pipes.
+#[cfg(windows)]
+#[derive(Debug)]
+pub struct NamedPipeListener(NamedPipeServer, std::ffi::OsString);
+
+#[cfg(windows)]
+impl NamedPipeListener {
+    /// Bind to a pipe path.
+    pub fn bind(pipe: impl Into<std::ffi::OsString>) -> std::io::Result<Self> {
+        let pipe = pipe.into();
+        Ok(NamedPipeListener(
+            ServerOptions::new()
+                .first_pipe_instance(true)
+                .create(&pipe)?,
+            pipe,
+        ))
+    }
+}
+
+/// Type representing a client to a Named Pipe
+#[cfg(windows)]
+#[derive(Debug)]
+pub struct NamedPipeClientInfo {
+    /// The client process identifier for the named pipe.
+    pub pid: u32,
+
+    /// the client session identifier for the named pipe.
+    pub session_id: u32,
+}
+
+#[cfg(windows)]
+#[async_trait]
+impl ListeningSocket for NamedPipeListener {
+    type Stream = NamedPipeServer;
+    type ClientInfo = NamedPipeClientInfo;
+
+    async fn accept(&mut self) -> io::Result<Self::Stream> {
+        self.0.connect().await?;
+        Ok(std::mem::replace(
+            &mut self.0,
+            ServerOptions::new().create(&self.1)?,
+        ))
+    }
+
+    fn client_info(stream: &Self::Stream) -> io::Result<Self::ClientInfo> {
+        let mut pid: u32 = Default::default();
+        let mut session_id: u32 = Default::default();
+
+        // SAFETY: This handle must be created by the CreateNamedPipe function.
+        // [`NamedPipeServer`]s are created with [`CreateNamedPipeW`] [1],
+        // and return `Err` if the handle is invalid [2]
+        //
+        // References:
+        // 1. https://docs.rs/tokio/latest/src/tokio/net/windows/named_pipe.rs.html#2345
+        // 2. https://docs.rs/tokio/latest/src/tokio/net/windows/named_pipe.rs.html#2356
+        unsafe {
+            GetNamedPipeClientProcessId(HANDLE(stream.as_raw_handle() as isize), &mut pid)?;
+            GetNamedPipeClientSessionId(HANDLE(stream.as_raw_handle() as isize), &mut session_id)?;
+        }
+
+        Ok(NamedPipeClientInfo { pid, session_id })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_debug_implementations)]
-#![deny(unsafe_code)]
+// #![deny(unsafe_code)]
 #![deny(missing_docs)]
 
 pub mod proto;


### PR DESCRIPTION
This PR is very much a work-in-progress, and I'm still unsure on a few things - but here goes nothing!

This adds:
- A `type ClientInfo` type parameter to `ListeningSocket`
- A `fn client_info(stream: &Self::Stream) -> io::Result<Self::ClientInfo>` method to `ListeningSocket`

The idea here being that a new `Session` is initialized with information about the connecting client, such as: 
> ```
> New connection from client: UnixClientInfo {
>    socket_addr: (unnamed),
>    credentials: UCred { pid: Some(73721), uid: 501, gid: 20 }
>}
>```

or on Windows:

> ```
> New connection from client: NamedPipeClientInfo { pid: 2684, session_id: 1 }
> ```
---

Now, for the issues:
- Type information: I can't figure out the best way to pass type information to the Agent implementation so that it can actually extract fields from the `ClientInfo` (specific to the Stream type)
- Windows: Oh man, don't even get me started on Windows!
  - To get anything usable from the name pipe, we need to make two unsafe calls to get the PID and Session ID for the client...

---

Alternatively, we can let Agent implementations extract this information from sockets themselves, but this would likely require an `enum` specifying the socket type, so you can consume socket-specific types. Not quite sure what the best option is - would love your thoughts!