### PR TITLE
Use `secrecy` crate to protect PINs from accidental leaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1080,7 @@ dependencies = [
  "rand",
  "rsa",
  "rstest",
+ "secrecy",
  "service-binding",
  "sha1",
  "signature",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "1.0.58"
 #uuid = { version = "1.8.0", features = ["v4"] }
 subtle = { version = "2", default-features = false }
 signature = { version = "2.2.0", features = ["alloc"] }
+secrecy = "0.8.0"
 
 [features]
 default = ["agent"]

--- a/src/proto/message.rs
+++ b/src/proto/message.rs
@@ -2,6 +2,7 @@
 
 use core::str::FromStr;
 
+use secrecy::{ExposeSecret as _, SecretString};
 use ssh_encoding::{CheckedSum, Decode, Encode, Error as EncodingError, Reader, Writer};
 use ssh_key::{
     certificate::Certificate, private::KeypairData, public::KeyData, Algorithm, Error, Signature,
@@ -349,7 +350,7 @@ impl Encode for RemoveIdentity {
 /// This structure is sent in a [`Request::AddSmartcardKey`] (`SSH_AGENTC_ADD_SMARTCARD_KEY`) message.
 ///
 /// Described in [draft-miller-ssh-agent-14 § 3.2](https://www.ietf.org/archive/id/draft-miller-ssh-agent-14.html#section-3.2)
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug)]
 pub struct SmartcardKey {
     /// An opaque identifier for the hardware token
     ///
@@ -358,7 +359,7 @@ pub struct SmartcardKey {
     pub id: String,
 
     /// An optional password to unlock the key
-    pub pin: String,
+    pub pin: SecretString,
 }
 
 impl Decode for SmartcardKey {
@@ -366,7 +367,7 @@ impl Decode for SmartcardKey {
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
         let id = String::decode(reader)?;
-        let pin = String::decode(reader)?;
+        let pin = String::decode(reader)?.into();
 
         Ok(Self { id, pin })
     }
@@ -374,14 +375,24 @@ impl Decode for SmartcardKey {
 
 impl Encode for SmartcardKey {
     fn encoded_len(&self) -> ssh_encoding::Result<usize> {
-        [self.id.encoded_len()?, self.pin.encoded_len()?].checked_sum()
+        [
+            self.id.encoded_len()?,
+            self.pin.expose_secret().encoded_len()?,
+        ]
+        .checked_sum()
     }
 
     fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
         self.id.encode(writer)?;
-        self.pin.encode(writer)?;
+        self.pin.expose_secret().encode(writer)?;
 
         Ok(())
+    }
+}
+
+impl PartialEq for SmartcardKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.pin.expose_secret() == other.pin.expose_secret()
     }
 }
 


### PR DESCRIPTION
Printing messages with the debug output appends secret data such as PINs to logs.

I think using `secrecy` is an easy way to make it a bit more explicit which data is sensitive and which isn't.

Happy to hear your suggestions!