### PR TITLE
Fix Extension encoded length

### DIFF
--- a/src/proto/message.rs
+++ b/src/proto/message.rs
@@ -617,7 +617,12 @@ impl Decode for Extension {
 
 impl Encode for Extension {
     fn encoded_len(&self) -> ssh_encoding::Result<usize> {
-        [self.name.encoded_len()?, self.details.0.encoded_len()?].checked_sum()
+        // NOTE: the below implementation of Encode::encode for Extension
+        // directly writes the bytes in `self.details` (and does not
+        // call Vec<u8>::encode). Vec<u8>::encoded_len counts 4 extra bytes
+        // for the u32 length field that Vec<u8>::encode would prepend.
+        // Therefore, use self.details.0's length directly.
+        [self.name.encoded_len()?, self.details.0.len()].checked_sum()
     }
 
     fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {


### PR DESCRIPTION
Extension is odd compared to other messages because its `Unparsed` payload does not include a length field. The implementation of `Encode::encode` for `Extension` accounts for this by writing the bytes directly from the `Vec<u8>` member of `Unparsed`, but the implementation of `Encode::encoded_len` for `Extension` did not account for the 4 extra bytes (a `u32`) that `<Vec<u8> as Encode>::encode` normally prepends.

Therefore, an Extension message on the wire claims it has 4 more bytes than its payload actually contains, which hangs most SSH agent server implementations waiting for the 4 additional bytes to arrive.