### PR TITLE
unparsed: expose content of the extension

### DIFF
--- a/src/proto/message/add_remove/constrained.rs
+++ b/src/proto/message/add_remove/constrained.rs
@@ -44,7 +44,7 @@ impl Decode for KeyConstraint {
                 let details: Vec<u8> = Vec::decode(reader)?;
                 KeyConstraint::Extension(Extension {
                     name,
-                    details: Unparsed::from(details),
+                    details: Unparsed::from_raw(details),
                 })
             }
             _ => return Err(KeyError::AlgorithmUnknown)?, // FIXME: it should be our own type

--- a/src/proto/message/extension.rs
+++ b/src/proto/message/extension.rs
@@ -32,11 +32,9 @@ impl Extension {
     where
         T: MessageExtension + Encode,
     {
-        let mut buffer: Vec<u8> = vec![];
-        extension.encode(&mut buffer)?;
         Ok(Self {
             name: T::NAME.into(),
-            details: buffer.into(),
+            details: Unparsed::new(&extension)?,
         })
     }
 
@@ -64,11 +62,9 @@ impl Extension {
     where
         T: KeyConstraintExtension + Encode,
     {
-        let mut buffer: Vec<u8> = vec![];
-        extension.encode(&mut buffer)?;
         Ok(Self {
             name: T::NAME.into(),
-            details: buffer.into(),
+            details: Unparsed::new(&extension)?,
         })
     }
 
@@ -100,7 +96,7 @@ impl Decode for Extension {
         reader.read(&mut details)?;
         Ok(Self {
             name,
-            details: details.into(),
+            details: Unparsed::from_raw(details),
         })
     }
 }

--- a/src/proto/message/unparsed.rs
+++ b/src/proto/message/unparsed.rs
@@ -16,6 +16,11 @@ impl Unparsed {
         let mut v = &self.0[..];
         T::decode(&mut v)
     }
+
+    /// Expose the inner content in raw format.
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
 }
 
 impl From<Vec<u8>> for Unparsed {

--- a/src/proto/message/unparsed.rs
+++ b/src/proto/message/unparsed.rs
@@ -18,14 +18,24 @@ impl Unparsed {
     }
 
     /// Expose the inner content in raw format.
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_raw(&self) -> &[u8] {
         self.0.as_slice()
     }
-}
 
-impl From<Vec<u8>> for Unparsed {
-    fn from(value: Vec<u8>) -> Self {
+    /// Creates a new value from a raw content
+    pub fn from_raw(value: Vec<u8>) -> Self {
         Self(value)
+    }
+
+    /// Creates an [`Unparsed`] content from a value.
+    /// The value will be encoded according to [`ssh_encoding::Encode`].
+    pub fn new<T>(value: &T) -> ssh_encoding::Result<Self>
+    where
+        T: ssh_encoding::Encode,
+    {
+        let mut buffer: Vec<u8> = vec![];
+        value.encode(&mut buffer)?;
+        Ok(Self(buffer))
     }
 }
 

--- a/tests/roundtrip/expected/req_add_identity_constrained_extension_restrict_destination.rs
+++ b/tests/roundtrip/expected/req_add_identity_constrained_extension_restrict_destination.rs
@@ -1,5 +1,7 @@
 use hex_literal::hex;
-use ssh_agent_lib::proto::{AddIdentity, AddIdentityConstrained, Credential, Extension, KeyConstraint, Request, Unparsed};
+use ssh_agent_lib::proto::{
+    AddIdentity, AddIdentityConstrained, Credential, Extension, KeyConstraint, Request, Unparsed,
+};
 use ssh_key::private::KeypairData;
 
 use super::fixtures;
@@ -14,7 +16,7 @@ pub fn expected() -> Request {
         },
         constraints: vec![KeyConstraint::Extension(Extension {
             name: "restrict-destination-v00@openssh.com".to_string(),
-            details: Unparsed::from(
+            details: Unparsed::from_raw(
                 hex!(
                     "                                    00
                     0002 6f00 0000 0c00 0000 0000 0000 0000


### PR DESCRIPTION
Unparsed is intended to hold the value of the extension. Specification calls for:
```
    byte             SSH_AGENTC_EXTENSION
    string           extension type
    byte[]           extension request-specific contents
```

But does not mandates for content to be serialized according to ssh regular serialization format (as in implements `ssh_encoding::Decode`).

The `Unparsed::From` implementation allows for content to be formatted in any serialization, but you can't read data back unless it was encoded according to SSH serialization.

This partially reverts https://github.com/wiktor-k/ssh-agent-lib/pull/67