### PR TITLE
Implement `AsRef<[u8]>` and `into_bytes(self)` for `Unparsed`

### DIFF
--- a/src/proto/message/unparsed.rs
+++ b/src/proto/message/unparsed.rs
@@ -16,11 +16,22 @@ impl Unparsed {
         let mut v = &self.0[..];
         T::decode(&mut v)
     }
+
+    /// Obtain the unparsed bytes as a `Vec<u8>`, consuming the `Unparsed`
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
 }
 
 impl From<Vec<u8>> for Unparsed {
     fn from(value: Vec<u8>) -> Self {
         Self(value)
+    }
+}
+
+impl AsRef<[u8]> for Unparsed {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }
 


### PR DESCRIPTION
Add conversion methods to gain access to the inner bytes of `Unparsed`,
per discussion in https://github.com/wiktor-k/ssh-agent-lib/pull/72

Signed-off-by: Ross Williams <ross@ross-williams.net>
