### PR TITLE
Set required features to examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,23 @@ secrecy = "0.10.3"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 interprocess = "2.4.0"
+
+[[example]]
+name = "agent-socket-info"
+required-features = ["agent"]
+
+[[example]]
+name = "key-storage"
+required-features = ["agent"]
+
+[[example]]
+name = "proto-dumper"
+required-features = ["agent"]
+
+[[example]]
+name = "random-key"
+required-features = ["agent"]
+
+[[example]]
+name = "ssh-agent-client"
+required-features = ["agent"]

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ version = 2
 yanked = "deny"
 ignore = [
   "RUSTSEC-2023-0071",  # the vurnerable crate is used in tests only
+  "RUSTSEC-2026-0097",  # the `log` and `thread_rng` features are not enabled
 ]
 
 [bans]


### PR DESCRIPTION
This command previously failed:

    cargo test --all-targets --no-default-features --features codec

Closes: https://github.com/wiktor-k/ssh-agent-lib/issues/102