### PR TITLE
Bump const-str from 0.5.7 to 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-str"
-version = "0.5.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
 
 [[package]]
 name = "cpufeatures"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ testresult = "0.4.1"
 hex-literal = "0.4.1"
 ssh-key = { version = "0.6.7", features = ["p256", "rsa"] }
 p256 = { version = "0.13.2" }
-const-str = "0.5.7"
+const-str = "1"
 rstest = "0.26.1"
 clap = { version = "4.5.61", features = ["derive"] }
 secrecy = "0.10.3"


### PR DESCRIPTION
Fedora already has 1.1.0, packaging an older version just for ssh-agent-lib seems unnecessary.

A lot of the changes are just dependency bumps; all tests pass

https://github.com/Nugine/const-str/compare/v0.5.7...v1.1.0